### PR TITLE
fix: variable name matched to backend

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -10,7 +10,7 @@ export interface Objective {
     id: string;
     name: string;
     description: string;
-    parentID: string;
+    parent_id: string;
 }
 
 export interface KeyResult {

--- a/src/routes/objectives/[objectiveID]/+page.ts
+++ b/src/routes/objectives/[objectiveID]/+page.ts
@@ -12,5 +12,5 @@ export const load: PageLoad = async ({ params }) => {
     if (!objective) {
         throw error(404, 'Not found');
     }
-    return { objectiveID: objective.id, objectiveName: objective.name, parentID: objective.parentID};
+    return { objectiveID: objective.id, objectiveName: objective.name, parentID: objective.parent_id};
 };


### PR DESCRIPTION
parentID in the frontend and parent_id in the backend caused problems in creating the key results