### PR TITLE
feat: add support for webauthn

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -9,8 +9,18 @@ import type {
 	User,
 } from "$lib/types";
 
-const baseFetch = (url: string, options: RequestInit = {}) => {
-	return fetch(`${PUBLIC_API_URL}${url}`, {
+export class APIError extends Error {
+	response: Response;
+
+	constructor(response: Response) {
+		super(response.statusText);
+
+		this.response = response;
+	}
+}
+
+const baseFetch = async (url: string, options: RequestInit = {}) => {
+	const response = await fetch(`${PUBLIC_API_URL}${url}`, {
 		credentials: "include",
 		...options,
 		headers: {
@@ -18,6 +28,13 @@ const baseFetch = (url: string, options: RequestInit = {}) => {
 			...(options.headers ?? {}),
 		},
 	});
+
+	// custom error handler that parses the Litestar JSON error format
+	if (!response.ok) {
+		throw new APIError(response);
+	}
+
+	return response;
 };
 
 export async function createUser(
@@ -34,13 +51,19 @@ export async function createUser(
 	return user;
 }
 
-export async function loginUser(username: string, password: string) {
+export async function loginUser(
+	username: string,
+	password: string,
+	two_fa_code: string | null,
+	authenticationResponse: Credential | null,
+) {
 	const response = await baseFetch("/login", {
 		method: "POST",
 		body: JSON.stringify({
 			name: username,
 			password: password,
-			two_fa_code: "",
+			two_fa_code: two_fa_code,
+			webauthn_response: authenticationResponse,
 		}),
 	});
 
@@ -337,4 +360,65 @@ export async function addObjectiveProject(
 	);
 
 	return response.json();
+}
+
+export async function getWebauthnRegistrationOptions() {
+	const response = await baseFetch(`/webauthn/registration_options`, {
+		method: "POST",
+	});
+
+	return response.json();
+}
+
+// biome-ignore lint/suspicious: the webauthn-internal response mustn't be parsed, so no type hints needed
+export async function webauthnRegister(
+	registrationResponse: Record<string, any>,
+) {
+	const response = await baseFetch(`/webauthn/register`, {
+		method: "POST",
+		body: JSON.stringify(registrationResponse),
+	});
+
+	return response.json();
+}
+
+export async function getWebauthnAuthenticationOptions(userId: string) {
+	const response = await baseFetch(
+		`/webauthn/authentication_options/${userId}`,
+		{
+			method: "POST",
+		},
+	);
+
+	return response.json();
+}
+
+export async function webauthnAuthenticate(
+	userId: string,
+	// biome-ignore lint/suspicious: the webauthn-internal response mustn't be parsed, so no type hints needed
+	authenticationResponse: Record<string, any>,
+) {
+	const response = await baseFetch(`/webauthn/authenticate/${userId}`, {
+		method: "POST",
+		body: JSON.stringify(authenticationResponse),
+	});
+
+	return response.json();
+}
+
+export async function webauthnRemoveCredentials(
+	userId: string,
+	// biome-ignore lint/suspicious: the webauthn-internal response mustn't be parsed, so no type hints needed
+	authenticationResponse: Record<string, any>,
+) {
+	await baseFetch(`/webauthn/remove_credentials/${userId}`, {
+		method: "DELETE",
+		body: JSON.stringify(authenticationResponse),
+	});
+}
+
+export async function webauthnIsConfigured(): Promise<boolean> {
+	const response = await baseFetch(`/webauthn/is_configured`);
+
+	return (await response.json()).is_configured;
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -43,3 +43,8 @@ export interface User {
 	email: string;
 	is_admin: boolean;
 }
+
+export interface TwoFaRequiredResponse {
+	type: "webauthn" | "totp";
+	user_id: string;
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -88,8 +88,8 @@ onMount(() => {
       <EllipsisIcon />
     </div>
     <ul tabindex="-1" class="dropdown-content menu bg-base-200 rounded-box z-1 w-52 p-2 shadow-sm">
+      <li class="btn btn-ghost" on:click={() => goto("/account")}>Account</li>
       <li class="btn btn-ghost" on:click={logoutUser}>Logout</li>
-      <li class="btn btn-ghost">Something else</li>
     </ul>
   </div>
 </div>

--- a/src/routes/account/+page.svelte
+++ b/src/routes/account/+page.svelte
@@ -1,0 +1,118 @@
+<script lang="ts">
+import {
+	getWebauthnAuthenticationOptions,
+	getWebauthnRegistrationOptions,
+	webauthnAuthenticate,
+	webauthnIsConfigured,
+	webauthnRegister,
+	webauthnRemoveCredentials,
+} from "$lib/api";
+import { userInfoStore } from "$lib/user_info";
+import { onMount } from "svelte";
+import { get } from "svelte/store";
+import ErrorMessage from "../../components/ErrorMessage.svelte";
+import { Check } from "@lucide/svelte";
+
+let isWebauthnConfigured = $state(false);
+let errorMessage: string | null = $state(null);
+let successMessage: string = $state("Passkey configured properly");
+
+async function registerWebauthn() {
+	const registrationOptions = PublicKeyCredential.parseCreationOptionsFromJSON(
+		await getWebauthnRegistrationOptions(),
+	);
+
+	const credential = await navigator.credentials.create({
+		publicKey: registrationOptions,
+	});
+
+	// if credential is null, the user canceled it
+	if (!credential) return;
+
+	try {
+		await webauthnRegister(credential);
+		isWebauthnConfigured = true;
+		// biome-ignore lint: exceptions are always of type any
+	} catch (e: any) {
+		errorMessage = e.toString();
+	}
+}
+
+async function loginWebauthn() {
+	const userId = get(userInfoStore)?.id;
+	if (!userId) return;
+
+	const authenticationOptions = PublicKeyCredential.parseRequestOptionsFromJSON(
+		await getWebauthnAuthenticationOptions(userId),
+	);
+
+	const credential = await navigator.credentials.get({
+		publicKey: authenticationOptions,
+	});
+
+	// if credential is null, the user canceled it
+	if (!credential) return;
+
+	try {
+		await webauthnAuthenticate(userId, credential);
+		successMessage = "Success! Your passkey works as expected.";
+		// biome-ignore lint: exceptions are always of type any
+	} catch (e: any) {
+		errorMessage = e.toString();
+	}
+}
+
+async function deleteWebauthnCredentials() {
+	const userId = get(userInfoStore)?.id;
+	if (!userId) return;
+
+	const authenticationOptions = PublicKeyCredential.parseRequestOptionsFromJSON(
+		await getWebauthnAuthenticationOptions(userId),
+	);
+
+	const credential = await navigator.credentials.get({
+		publicKey: authenticationOptions,
+	});
+
+	// if credential is null, the user canceled it
+	if (!credential) return;
+
+	try {
+		await webauthnRemoveCredentials(userId, credential);
+		isWebauthnConfigured = false;
+		// biome-ignore lint: exceptions are always of type any
+	} catch (e: any) {
+		errorMessage = e.toString();
+	}
+}
+
+onMount(async () => {
+	isWebauthnConfigured = await webauthnIsConfigured();
+});
+</script>
+
+<div class="p-3">
+  <h2>Configure Account</h2>
+
+  <div class="card card-border mt-3">
+  	<h2 class="card-title">Webauthn</h2>
+
+  	<div class="card-body">
+		  <ErrorMessage message={errorMessage} />
+		  {#if !isWebauthnConfigured}
+			  <button class="btn btn-primary w-max" onclick={() => registerWebauthn()}>Register passkey</button>
+		  {/if}
+		  {#if isWebauthnConfigured}
+		  	<div class="alert alert-success">
+		  		<Check size="16" />
+		  		<span>{ successMessage }</span>
+				</div>
+
+				<div class="flex gap-3">
+				  <button class="btn btn-primary w-max" onclick={() => loginWebauthn()}>Login with passkey</button>
+				  <button class="btn btn-primary w-max" onclick={() => deleteWebauthnCredentials()}>Delete passkey</button>
+			  </div>
+		  {/if}
+	  </div>
+  </div>
+</div>

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -1,13 +1,22 @@
 <script lang="ts">
 import { _ } from "svelte-i18n";
 import { goto } from "$app/navigation";
-import { loginUser } from "$lib/api";
+import {
+	APIError,
+	getWebauthnAuthenticationOptions,
+	loginUser,
+} from "$lib/api";
 import { setUserInfo as setUserInfoWithStorageCache } from "$lib/user_info";
-import type { User } from "$lib/types";
+import type { TwoFaRequiredResponse, User } from "$lib/types";
 
 let username: string = $state("");
 let password: string = $state("");
 let errorMessage: string = $state("");
+
+// webauthn specific
+let webauthnRequired: boolean = $state(false);
+let userId: string | null = $state(null);
+let webauthnCredential: Credential | null = $state(null);
 
 async function login(e: SubmitEvent) {
 	e.preventDefault();
@@ -18,13 +27,39 @@ async function login(e: SubmitEvent) {
 	}
 
 	try {
-		const userInfo: User = await loginUser(username, password);
+		const userInfo: User = await loginUser(
+			username,
+			password,
+			null,
+			webauthnCredential,
+		);
 		setUserInfoWithStorageCache(userInfo);
 		await goto("/");
 	} catch (e) {
+		// correct credentials, but second factor is missing
+		if (e instanceof APIError && e.response.status === 403) {
+			const twoFaRequiredResponse: TwoFaRequiredResponse = (
+				await e.response.json()
+			).extra;
+			userId = twoFaRequiredResponse.user_id;
+			if (twoFaRequiredResponse.type === "webauthn") webauthnRequired = true;
+			return;
+		}
 		console.error(e);
 		errorMessage = "Wrong username or password.";
 	}
+}
+
+async function loadWebauthn() {
+	if (!userId) return;
+
+	const authenticationOptions = PublicKeyCredential.parseRequestOptionsFromJSON(
+		await getWebauthnAuthenticationOptions(userId),
+	);
+
+	webauthnCredential = await navigator.credentials.get({
+		publicKey: authenticationOptions,
+	});
 }
 </script>
 
@@ -38,6 +73,9 @@ async function login(e: SubmitEvent) {
 		{/if}
 	  <input type="text" id="username" bind:value={username} placeholder={$_('username')} class="input w-full" >
 	  <input type="password" id="password" bind:value={password} placeholder={$_('password')} class="input w-full" >
-	  <input type="submit" value={$_('login')} class="btn btn-primary">
+	  {#if webauthnRequired}
+		  <button type="button" class="btn btn-primary" onclick={() => loadWebauthn()}>Load passkey</button>
+		{/if}
+	  <input type="submit" value={$_('login')} class="btn btn-primary" disabled={webauthnRequired && !webauthnCredential}>
 	</form>
 </div>


### PR DESCRIPTION
requires https://github.com/tpse-81/okr/pull/90

To test:
- Install a browser extension that supports Webauthn (e.g. Bitwarden)
- If using Bitwarden, go to Settings -> Notifications -> Excluded Domains and make sure that "localhost" is not part of the list (or remove it from there)
- Login normally
- Press the three dots at the top right and select "Account"
- Press "Register passkey" and follow the advice on the screen
- Logout
- Try to log in