### PR TITLE
fix: can't set task status to 'in progress'

### DIFF
--- a/src/components/DashboardTask.svelte
+++ b/src/components/DashboardTask.svelte
@@ -17,7 +17,7 @@ import EditTaskComponent from "./EditTaskComponent.svelte";
 const taskStates: { state: TaskState; label: string; badge: string }[] = [
 	{ state: "open", label: "tasks.open", badge: "badge-ghost" },
 	{ state: "planned", label: "tasks.planned", badge: "badge-warning" },
-	{ state: "inProgress", label: "tasks.inProgress", badge: "badge-info" },
+	{ state: "in_progress", label: "tasks.in_progress", badge: "badge-info" },
 	{ state: "done", label: "tasks.done", badge: "badge-success" },
 	{ state: "cancelled", label: "tasks.cancelled", badge: "badge-error" },
 ];

--- a/src/components/EditTaskComponent.svelte
+++ b/src/components/EditTaskComponent.svelte
@@ -43,7 +43,7 @@ async function onUpdateTask() {
 	    <select bind:value={taskState} class="select select-bordered">
 	        <option value="open">{$_("tasks.open")}</option>
 	        <option value="planned">{$_("tasks.planned")}</option>
-	        <option value="inProgress">{$_("tasks.inProgress")}</option>
+	        <option value="in_progress">{$_("tasks.in_progress")}</option>
 	        <option value="done">{$_("tasks.done")}</option>
 	        <option value="cancelled">{$_("tasks.cancelled")}</option>
 	    </select>

--- a/src/lib/i18n/locales/de.json
+++ b/src/lib/i18n/locales/de.json
@@ -74,7 +74,7 @@
 		"state": "Status",
 		"open": "Offen",
 		"planned": "Geplant",
-		"inProgress": "In Bearbeitung",
+		"in_progress": "In Bearbeitung",
 		"done": "Erledigt",
 		"cancelled": "Abgebrochen",
 		"createTitle": "Aufgabe erstellen",

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -74,7 +74,7 @@
 		"state": "State",
 		"open": "Open",
 		"planned": "Planned",
-		"inProgress": "In progress",
+		"in_progress": "In progress",
 		"done": "Done",
 		"cancelled": "Cancelled",
 		"createTitle": "Create a Task",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -32,7 +32,7 @@ export interface KeyResult {
 export type TaskState =
 	| "open"
 	| "planned"
-	| "inProgress"
+	| "in_progress"
 	| "done"
 	| "cancelled";
 

--- a/src/routes/key_results/[keyResultID]/+page.svelte
+++ b/src/routes/key_results/[keyResultID]/+page.svelte
@@ -46,7 +46,7 @@ async function handleSubmit(e: SubmitEvent) {
     <select bind:value={taskState} class="select select-bordered">
         <option value="open">{$_("tasks.open")}</option>
         <option value="planned">{$_("tasks.planned")}</option>
-        <option value="inProgress">{$_("tasks.inProgress")}</option>
+        <option value="in_progress">{$_("tasks.in_progress")}</option>
         <option value="done">{$_("tasks.done")}</option>
         <option value="cancelled">{$_("tasks.cancelled")}</option>
     </select>


### PR DESCRIPTION
The backend returns the task state as `in_progress`, while the translations PR changed it to `inProgress`