### PR TITLE
fix: app crashes on dynamic path route (i.e. url path contains an ID)

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,0 +1,13 @@
+import type { HandleFetch } from "@sveltejs/kit";
+import { AUTH_TOKEN_NAME } from "$lib/api";
+
+export const handleFetch: HandleFetch = async ({ event, request, fetch }) => {
+	// this ensures that all API calls done on the server side also have
+	// access to the jwt token required for authentication
+	// see https://svelte.dev/docs/kit/hooks#Server-hooks-handleFetch
+
+	const token = event.cookies.get(AUTH_TOKEN_NAME);
+	if (token) request.headers.set(AUTH_TOKEN_NAME, token);
+
+	return fetch(request);
+};

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -2,6 +2,7 @@
 import { env } from "$env/dynamic/public";
 
 const PUBLIC_API_URL = env.PUBLIC_API_URL;
+export const AUTH_TOKEN_NAME = "token";
 
 import type {
 	KeyResult,
@@ -22,8 +23,29 @@ export class APIError extends Error {
 	}
 }
 
-const baseFetch = async (url: string, options: RequestInit = {}) => {
-	const response = await fetch(`${PUBLIC_API_URL}${url}`, {
+type FetchMethod = (
+	input: RequestInfo | URL,
+	init?: RequestInit,
+) => Promise<Response>;
+
+/**
+ * Fetch data from the API.
+ *
+ * If there is a chance that this code is executed on server-side, the custom `fetch`-method
+ * from the `load` method in `+page.server.ts` MUST be passed here.
+ **/
+const baseFetch = async (
+	url: string,
+	options: RequestInit = {},
+	customFetch: FetchMethod | null = null,
+) => {
+	// this is required for server-side loading of application data -
+	// if a server-side fetch method is provided, we have to use this one instead
+	// this ensures that auth tokens are sent properly, otherwise the server side
+	// request would omit this data, causing the API to return a Forbidden error
+	const fetchMethod = customFetch ?? fetch;
+
+	const response = await fetchMethod(`${PUBLIC_API_URL}${url}`, {
 		credentials: "include",
 		...options,
 		headers: {
@@ -173,8 +195,11 @@ export async function createProject(
 	return response;
 }
 
-export async function getProject(project_id: string): Promise<Project> {
-	const response = await baseFetch(`/projects/${project_id}`);
+export async function getProject(
+	project_id: string,
+	customFetch: FetchMethod | null = null,
+): Promise<Project> {
+	const response = await baseFetch(`/projects/${project_id}`, {}, customFetch);
 
 	return response.json();
 }
@@ -248,8 +273,15 @@ export async function createObjective(
 	return response;
 }
 
-export async function getObjective(objective_id: string): Promise<Objective> {
-	const response = await baseFetch(`/objectives/${objective_id}`);
+export async function getObjective(
+	objective_id: string,
+	customFetch: FetchMethod | null = null,
+): Promise<Objective> {
+	const response = await baseFetch(
+		`/objectives/${objective_id}`,
+		{},
+		customFetch,
+	);
 
 	return response.json();
 }
@@ -383,8 +415,15 @@ export async function createKeyResult(
 	return response.json();
 }
 
-export async function getKeyResult(key_result_id: string): Promise<KeyResult> {
-	const response = await baseFetch(`/key_results/${key_result_id}`);
+export async function getKeyResult(
+	key_result_id: string,
+	customFetch: FetchMethod | null = null,
+): Promise<KeyResult> {
+	const response = await baseFetch(
+		`/key_results/${key_result_id}`,
+		{},
+		customFetch,
+	);
 
 	return response.json();
 }

--- a/src/routes/key_results/[keyResultID]/+page.ts
+++ b/src/routes/key_results/[keyResultID]/+page.ts
@@ -3,9 +3,9 @@ import { getKeyResult } from "$lib/api";
 import type { KeyResult } from "$lib/types";
 import type { PageLoad } from "./$types";
 
-export const load: PageLoad = async ({ params }) => {
+export const load: PageLoad = async ({ fetch, params }) => {
 	try {
-		const keyResult: KeyResult = await getKeyResult(params.keyResultID);
+		const keyResult: KeyResult = await getKeyResult(params.keyResultID, fetch);
 		return { keyResultID: keyResult.id };
 	} catch (_) {
 		throw error(404, "Not found");

--- a/src/routes/objectives/[objectiveID]/+page.ts
+++ b/src/routes/objectives/[objectiveID]/+page.ts
@@ -3,9 +3,9 @@ import { getObjective } from "$lib/api";
 import type { Objective } from "$lib/types";
 import type { PageLoad } from "./$types";
 
-export const load: PageLoad = async ({ params }) => {
+export const load: PageLoad = async ({ fetch, params }) => {
 	try {
-		const objective: Objective = await getObjective(params.objectiveID);
+		const objective: Objective = await getObjective(params.objectiveID, fetch);
 		return {
 			objectiveID: objective.id,
 			objectiveName: objective.name,

--- a/src/routes/projects/[projectID]/+page.ts
+++ b/src/routes/projects/[projectID]/+page.ts
@@ -3,9 +3,9 @@ import { getProject } from "$lib/api";
 import type { Project } from "$lib/types";
 import type { PageLoad } from "./$types";
 
-export const load: PageLoad = async ({ params }) => {
+export const load: PageLoad = async ({ fetch, params }) => {
 	try {
-		const project: Project = await getProject(params.projectID);
+		const project: Project = await getProject(params.projectID, fetch);
 		return {
 			project_id: project.id,
 			project_name: project.name,


### PR DESCRIPTION
This feels ugly, but idk how else we could fix it.

The simplest way would be to disable server-side rendering (i.e. all HTTP requests are only done from the user's browser), but that's not a clean solution.

closes #127

Please read see https://svelte.dev/docs/kit/hooks#Server-hooks-handleFetch.